### PR TITLE
[WIP] Enable inline diagnostics for LSP

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2029,10 +2029,12 @@ function M._split_line_diags_per_col(line_diags)
 
     for _, diag in ipairs(diags) do
       -- Get all col diags:
-      local lcd_lnum_lcol = lcd_lnum[diag.end_col]
+      local endcol = diag.end_col and diag.end_col or 0
+      -- If no end_col is provided, fallback to start of line.
+      local lcd_lnum_lcol = lcd_lnum[endcol]
       if not lcd_lnum_lcol then
         lcd_lnum_lcol = {}
-        lcd_lnum[diag.end_col] = lcd_lnum_lcol
+        lcd_lnum[endcol] = lcd_lnum_lcol
       end
 
       -- Insert in the line,col appropriate:


### PR DESCRIPTION
Given this file (notice the trailing space in line 2):

```lua
local foo = 'hello'
 
local t = { foo = bar }
```

and the following `minimal.lua` file:

```lua
for name, url in pairs {
  ['nvim-lspconfig'] = 'https://github.com/neovim/nvim-lspconfig',
  -- 'https://github.com/author2/plugin2',
} do
  local install_path = vim.fn.fnamemodify('nvim-issue-diagnostics/' .. name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end


local M = {}
M.settings = {
	Lua = {
		-- Provide lua version and always enable std-lib:
		runtime = { version = 'LuaJIT', builtin = 'Disabled', },
		-- Make lua-language-server aware of the built-in 'vim' global variable:
		diagnostics = { enable = true, globals = {}, },
		workspace = { library = {}, checkThirdParty = 'Disabled', },
		telemetry = { enable = false, }
	},
}
M.filetypes = { 'lua' }
M.root_markers = { ".luarc.json", ".luarc.jsonc", ".luacheckrc", ".stylua.toml", "stylua.toml", "selene.toml", "selene.yml", ".git", "init.lua" }

vim.lsp.config('lua_ls', M)
vim.lsp.enable('lua_ls')

vim.diagnostic.config({
	virtual_text = {
		current_line = false,
		source = true,
		spacing = 1,
		severity = { min = vim.diagnostic.severity.INFO, max = vim.diagnostic.severity.ERROR, },
		virt_text_pos = 'inline',
		hl_mode = 'replace',
		prefix = '󰌶 ',
		suffix = nil,
	},
	float = { border = "rounded" },
	signs = {
		text = {
			[vim.diagnostic.severity.ERROR] = '',
			[vim.diagnostic.severity.WARN] = '',
			[vim.diagnostic.severity.INFO] = '',
			[vim.diagnostic.severity.HINT] = '',
		},
	},
	severity_sort = true,
	update_in_insert = false,
})
```

The LSP diagnostics are all bunched on the left-most column.

This PR will track all my thoughts, as I cannot easily enable issues on this repository.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
